### PR TITLE
more explicitly check for missing user

### DIFF
--- a/build/core/TikTok.js
+++ b/build/core/TikTok.js
@@ -641,10 +641,13 @@ class TikTokScraper extends events_1.EventEmitter {
         try {
             const response = await this.request(options);
             if (!response) {
+                throw new Error(`An unknown error occurred: ${this.input}`);
+            }
+            else if (response.statusCode === 10202) {
                 throw new Error(`Can't find user: ${this.input}`);
             }
-            if (response.statusCode !== 0) {
-                throw new Error(`Can't find user: ${this.input}`);
+            else if (response.statusCode !== 0) {
+                throw new Error(`An unknown error occurred: ${this.input}`);
             }
             return response.userInfo;
         }

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -943,11 +943,13 @@ export class TikTokScraper extends EventEmitter {
             const response = await this.request<TikTokMetadata>(options);
 
             if (!response) {
+                throw new Error(`An unknown error occurred: ${this.input}`);
+            } else if (response.statusCode === 10202) {
                 throw new Error(`Can't find user: ${this.input}`);
+            } else if (response.statusCode !== 0) {
+                throw new Error(`An unknown error occurred: ${this.input}`);
             }
-            if (response.statusCode !== 0) {
-                throw new Error(`Can't find user: ${this.input}`);
-            }
+
             return response.userInfo;
         } catch (error) {
             throw error.message;


### PR DESCRIPTION
The library is raising "Can't find user" errors which implied the user is missing even when other types of errors were happening. This makes the errors that are raised more explicit.