### PR TITLE
Update CSRF Token to 92 Characters

### DIFF
--- a/build/entry.js
+++ b/build/entry.js
@@ -33,7 +33,7 @@ const getInitOptions = () => {
             'user-agent': constant_1.default.userAgent(),
             referer: 'https://www.tiktok.com/',
             cookie: `tt_webid_v2=68${helpers_1.makeid(16)}`,
-            'x-secsdk-csrf-token': `${helpers_1.makeid(30)}`,
+            'x-secsdk-csrf-token': `${helpers_1.makeid(92)}`,
         },
     };
 };

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -45,7 +45,7 @@ const getInitOptions = () => {
             'user-agent': CONST.userAgent(),
             referer: 'https://www.tiktok.com/',
             cookie: `tt_webid_v2=68${makeid(16)}`,
-            'x-secsdk-csrf-token': `${makeid(30)}`,
+            'x-secsdk-csrf-token': `${makeid(92)}`,
         },
     };
 };


### PR DESCRIPTION
This fix has not been merged into `drawrowfly/master` yet, so fixing for us now.