### PR TITLE
Update CSRF Token to 30 char

### DIFF
--- a/build/entry.js
+++ b/build/entry.js
@@ -33,7 +33,7 @@ const getInitOptions = () => {
             'user-agent': constant_1.default.userAgent(),
             referer: 'https://www.tiktok.com/',
             cookie: `tt_webid_v2=68${helpers_1.makeid(16)}`,
-            'x-secsdk-csrf-token': `${helpers_1.makeid(92)}`,
+            'x-secsdk-csrf-token': `${helpers_1.makeid(30)}`,
         },
     };
 };

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -45,7 +45,7 @@ const getInitOptions = () => {
             'user-agent': CONST.userAgent(),
             referer: 'https://www.tiktok.com/',
             cookie: `tt_webid_v2=68${makeid(16)}`,
-            'x-secsdk-csrf-token': `${makeid(92)}`,
+            'x-secsdk-csrf-token': `${makeid(30)}`,
         },
     };
 };


### PR DESCRIPTION
use 30 character ID in order to avoid merge conflict with new 1.4.25 update: https://github.com/PopularPays/tiktok-scraper/pull/20